### PR TITLE
Fix UE 5.7 compatibility (5 breaking changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Describe intent → Execute → Screenshot → AI analyzes → Iterate
 
 ### Requirements
 
-- Unreal Engine 5.6 or later
+- Unreal Engine 5.6 or later (includes UE 5.7 compatibility fixes)
 - Windows, Mac, or Linux
-- MCP-compatible client (Cursor, Claude Desktop, etc.)
+- MCP-compatible client (Claude Code, Claude Desktop, Cursor, etc.)
 
 ### Setup
 
@@ -77,13 +77,44 @@ Describe intent → Execute → Screenshot → AI analyzes → Iterate
        └── SpecialAgent/
    ```
 
-2. **Regenerate project files** (right-click `.uproject` → Generate Visual Studio/Xcode project files)
+2. **Enable required plugins** in your `.uproject` file (or via Edit → Plugins):
+   - `PythonScriptPlugin` — required for Python execution
+   - `EditorScriptingUtilities` — required for editor scripting API
 
-3. **Build and launch** your project
+   To enable via `.uproject`, add these entries to the `"Plugins"` array:
+   ```json
+   {
+       "Name": "PythonScriptPlugin",
+       "Enabled": true
+   },
+   {
+       "Name": "EditorScriptingUtilities",
+       "Enabled": true
+   }
+   ```
 
-4. **Enable the plugin** in Edit → Plugins → Search "SpecialAgent"
+3. **Regenerate project files** (right-click `.uproject` → Generate Visual Studio/Xcode project files)
 
-5. **Restart** the editor
+4. **Build and launch** your project
+
+5. **Enable SpecialAgent** in Edit → Plugins → Search "SpecialAgent"
+
+6. **Restart** the editor
+
+### UE 5.7 Notes
+
+If you are using **Unreal Engine 5.7+**, be aware of these API changes that affect Python scripts:
+
+- **`EditorLevelLibrary` is removed.** Use subsystems instead:
+  ```python
+  # UE 5.6 (deprecated):
+  unreal.EditorLevelLibrary.spawn_actor_from_class(...)
+
+  # UE 5.7+:
+  subsystem = unreal.get_editor_subsystem(unreal.EditorActorSubsystem)
+  subsystem.spawn_actor_from_class(...)
+  ```
+- All 5.7-specific fixes are already applied in this branch. See [UE57_FIXES.md](UE57_FIXES.md) for details.
 
 ---
 
@@ -262,7 +293,7 @@ Both layers work together: quick tools for common tasks, unlimited scripting for
 
 | Specification | Value |
 |--------------|-------|
-| Engine Version | UE 5.6+ |
+| Engine Version | UE 5.6–5.7+ |
 | Platforms | Windows, Mac, Linux |
 | Module Type | Editor |
 | Transport | HTTP/SSE (native) |

--- a/Source/SpecialAgent/Private/MCPRequestRouter.cpp
+++ b/Source/SpecialAgent/Private/MCPRequestRouter.cpp
@@ -496,7 +496,7 @@ FMCPResponse FMCPRequestRouter::HandlePromptsGet(const FMCPRequest& Request)
 			"Help me place objects in the level: %s\n\n"
 			"Use Python (python/execute) with the unreal module to:\n"
 			"1. First screenshot to see the current state\n"
-			"2. Use unreal.EditorLevelLibrary or unreal.EditorAssetLibrary as needed\n"
+			"2. Use unreal.get_editor_subsystem(unreal.EditorActorSubsystem) for actor ops, unreal.EditorAssetLibrary for assets\n"
 			"3. Place/modify the requested objects\n"
 			"4. Screenshot again to verify the results"
 		), *Description));

--- a/Source/SpecialAgent/Private/MCPServer.cpp
+++ b/Source/SpecialAgent/Private/MCPServer.cpp
@@ -33,13 +33,10 @@ bool FSpecialAgentMCPServer::StartServer(int32 Port)
 
 	// Get the HTTP server module
 	FHttpServerModule& HttpServerModule = FHttpServerModule::Get();
-	
-	// Start listeners on the specified port
-	HttpServerModule.StartAllListeners();
-	
-	// Get the HTTP router for our port
+
+	// UE 5.7: Get router FIRST, bind routes, THEN start listeners
 	HttpRouter = HttpServerModule.GetHttpRouter(ServerPort);
-	
+
 	if (!HttpRouter.IsValid())
 	{
 		UE_LOG(LogTemp, Error, TEXT("SpecialAgent: Failed to get HTTP router for port %d"), ServerPort);
@@ -99,6 +96,9 @@ bool FSpecialAgentMCPServer::StartServer(int32 Port)
 		EHttpServerRequestVerbs::VERB_OPTIONS,
 		FHttpRequestHandler::CreateRaw(this, &FSpecialAgentMCPServer::HandleCORS)
 	);
+
+	// UE 5.7: Start listeners AFTER all routes are bound
+	HttpServerModule.StartAllListeners();
 
 	bIsRunning = true;
 	UE_LOG(LogTemp, Log, TEXT("SpecialAgent: MCP HTTP Server started on port %d"), ServerPort);

--- a/Source/SpecialAgent/Private/Services/PythonService.cpp
+++ b/Source/SpecialAgent/Private/Services/PythonService.cpp
@@ -26,7 +26,7 @@ TArray<FMCPToolInfo> FPythonService::GetAvailableTools() const
 	{
 		FMCPToolInfo Tool;
 		Tool.Name = TEXT("execute");
-		Tool.Description = TEXT("Execute Python with full UE5 API. Use for: spawning actors (unreal.EditorLevelLibrary), modifying properties, batch operations, anything not covered by other tools. Import 'unreal' module is automatic.");
+		Tool.Description = TEXT("Execute Python with full UE5 API. Use for: spawning actors (unreal.get_editor_subsystem(unreal.EditorActorSubsystem)), modifying properties, batch operations, anything not covered by other tools. Import 'unreal' module is automatic.");
 		
 		TSharedPtr<FJsonObject> CodeParam = MakeShared<FJsonObject>();
 		CodeParam->SetStringField(TEXT("type"), TEXT("string"));

--- a/Source/SpecialAgent/Private/Services/WorldService.cpp
+++ b/Source/SpecialAgent/Private/Services/WorldService.cpp
@@ -9,7 +9,9 @@
 #include "Editor.h"
 #include "GameFramework/Actor.h"
 #include "GameFramework/WorldSettings.h"
-#include "EditorLevelLibrary.h"
+// UE 5.7: EditorLevelLibrary is deprecated; use subsystems instead
+#include "Subsystems/EditorActorSubsystem.h"
+#include "Subsystems/UnrealEditorSubsystem.h"
 #include "Components/StaticMeshComponent.h"
 #include "Engine/StaticMeshActor.h"
 #include "Engine/StaticMesh.h"

--- a/Source/SpecialAgent/Private/SpecialAgentModule.cpp
+++ b/Source/SpecialAgent/Private/SpecialAgentModule.cpp
@@ -28,10 +28,12 @@ void FSpecialAgentModule::StartupModule()
 	int32 ServerPort = 8767;  // HTTP/SSE port for MCP client connections
 	
 	// Try to read from config (may not exist yet)
+	// UE 5.7: Use explicit config file path instead of GGameIni
 	if (GConfig)
 	{
-		GConfig->GetBool(TEXT("/Script/SpecialAgent.SpecialAgentSettings"), TEXT("ServerEnabled"), bAutoStart, GGameIni);
-		GConfig->GetInt(TEXT("/Script/SpecialAgent.SpecialAgentSettings"), TEXT("ServerPort"), ServerPort, GGameIni);
+		const FString ConfigPath = FPaths::ProjectConfigDir() / TEXT("DefaultSpecialAgent.ini");
+		GConfig->GetBool(TEXT("/Script/SpecialAgent.SpecialAgentSettings"), TEXT("ServerEnabled"), bAutoStart, ConfigPath);
+		GConfig->GetInt(TEXT("/Script/SpecialAgent.SpecialAgentSettings"), TEXT("ServerPort"), ServerPort, ConfigPath);
 	}
 	
 	UE_LOG(LogTemp, Log, TEXT("SpecialAgent: ServerEnabled=%d, ServerPort=%d"), bAutoStart, ServerPort);
@@ -90,17 +92,32 @@ void FSpecialAgentModule::RegisterStatusBarWidget()
 	if (StatusBarMenu)
 	{
 		TSharedPtr<FSpecialAgentMCPServer> Server = MCPServer;
-		
-		FToolMenuSection& Section = StatusBarMenu->FindOrAddSection(TEXT("SpecialAgent"));
-		Section.AddEntry(FToolMenuEntry::InitWidget(
-			TEXT("MCPStatus"),
-			SNew(SMCPStatusBarWidget, Server),
-			FText::GetEmpty(),
-			true,  // bNoIndent
-			false  // bSearchable
-		));
-		
-		UE_LOG(LogTemp, Log, TEXT("SpecialAgent: Status bar widget registered via ToolMenus"));
+
+		// UE 5.7: FindOrAddSection() was removed. Use AddSection() + FindSection() pattern.
+		const FName SectionName = TEXT("SpecialAgent");
+		FToolMenuSection* Section = StatusBarMenu->FindSection(SectionName);
+		if (!Section)
+		{
+			StatusBarMenu->AddSection(SectionName, LOCTEXT("SpecialAgentSection", "SpecialAgent"));
+			Section = StatusBarMenu->FindSection(SectionName);
+		}
+
+		if (Section)
+		{
+			Section->AddEntry(FToolMenuEntry::InitWidget(
+				TEXT("MCPStatus"),
+				SNew(SMCPStatusBarWidget, Server),
+				FText::GetEmpty(),
+				true,  // bNoIndent
+				false  // bSearchable
+			));
+
+			UE_LOG(LogTemp, Log, TEXT("SpecialAgent: Status bar widget registered via ToolMenus"));
+		}
+		else
+		{
+			UE_LOG(LogTemp, Warning, TEXT("SpecialAgent: Could not create ToolMenu section"));
+		}
 	}
 	else
 	{

--- a/UE57_FIXES.md
+++ b/UE57_FIXES.md
@@ -1,0 +1,128 @@
+# SpecialAgent UE 5.7 Compatibility Fixes
+
+These fixes were identified and applied during a live UE 5.7.3 build session.
+The plugin compiled and ran successfully after these changes.
+
+## Summary of Changes (5 files)
+
+### 1. `Source/SpecialAgent/Private/SpecialAgentModule.cpp`
+
+**Problem:** `FToolMenuSection::FindOrAddSection()` was removed in UE 5.7.
+
+**Fix:** Replace with `AddSection()` + `FindSection()` pattern:
+
+```cpp
+// BEFORE (UE 5.5/5.6):
+FToolMenuSection& Section = StatusBarMenu->FindOrAddSection(TEXT("SpecialAgent"));
+Section.AddEntry(...);
+
+// AFTER (UE 5.7):
+const FName SectionName = TEXT("SpecialAgent");
+FToolMenuSection* Section = StatusBarMenu->FindSection(SectionName);
+if (!Section)
+{
+    StatusBarMenu->AddSection(SectionName, LOCTEXT("SpecialAgentSection", "SpecialAgent"));
+    Section = StatusBarMenu->FindSection(SectionName);
+}
+if (Section)
+{
+    Section->AddEntry(...);
+}
+```
+
+**Problem 2:** `GGameIni` is deprecated in UE 5.7.
+
+**Fix:** Use explicit config file path:
+
+```cpp
+// BEFORE:
+GConfig->GetBool(TEXT("..."), TEXT("ServerEnabled"), bAutoStart, GGameIni);
+GConfig->GetInt(TEXT("..."), TEXT("ServerPort"), ServerPort, GGameIni);
+
+// AFTER:
+const FString ConfigPath = FPaths::ProjectConfigDir() / TEXT("DefaultSpecialAgent.ini");
+GConfig->GetBool(TEXT("..."), TEXT("ServerEnabled"), bAutoStart, ConfigPath);
+GConfig->GetInt(TEXT("..."), TEXT("ServerPort"), ServerPort, ConfigPath);
+```
+
+---
+
+### 2. `Source/SpecialAgent/Private/MCPServer.cpp`
+
+**Problem:** `StartAllListeners()` was called BEFORE routes were bound, causing the server
+to start accepting connections before any handlers were registered — resulting in 404s on all requests.
+
+**Fix:** Move `StartAllListeners()` to AFTER all `BindRoute()` calls:
+
+```cpp
+// BEFORE (broken ordering):
+HttpServerModule.StartAllListeners();   // ← too early
+HttpRouter = HttpServerModule.GetHttpRouter(ServerPort);
+HttpRouter->BindRoute(...);  // routes bound after server started
+
+// AFTER (correct):
+HttpRouter = HttpServerModule.GetHttpRouter(ServerPort);
+HttpRouter->BindRoute(...);  // bind all routes first
+HttpRouter->BindRoute(...);
+// ... all routes ...
+HttpServerModule.StartAllListeners();   // ← start AFTER routes are registered
+```
+
+---
+
+### 3. `Source/SpecialAgent/Private/Services/WorldService.cpp`
+
+**Problem:** `#include "EditorLevelLibrary.h"` — `EditorLevelLibrary` is fully deprecated
+and removed in UE 5.7. Causes compile error.
+
+**Fix:**
+```cpp
+// BEFORE:
+#include "EditorLevelLibrary.h"
+
+// AFTER:
+// UE 5.7: EditorLevelLibrary is deprecated; use subsystems instead
+#include "Subsystems/EditorActorSubsystem.h"
+#include "Subsystems/UnrealEditorSubsystem.h"
+```
+
+---
+
+### 4. `Source/SpecialAgent/Private/MCPRequestRouter.cpp`
+
+**Fix:** Updated documentation string to reference the correct UE 5.7 API:
+
+```cpp
+// BEFORE:
+"2. Use unreal.EditorLevelLibrary or unreal.EditorAssetLibrary as needed\n"
+
+// AFTER:
+"2. Use unreal.get_editor_subsystem(unreal.EditorActorSubsystem) for actor ops, unreal.EditorAssetLibrary for assets\n"
+```
+
+---
+
+### 5. `Source/SpecialAgent/Private/Services/PythonService.cpp`
+
+**Fix:** Updated tool description to reference the correct UE 5.7 Python API:
+
+```cpp
+// BEFORE:
+Tool.Description = TEXT("Execute Python with full UE5 API. Use for: spawning actors (unreal.EditorLevelLibrary)...");
+
+// AFTER:
+Tool.Description = TEXT("Execute Python with full UE5 API. Use for: spawning actors (unreal.get_editor_subsystem(unreal.EditorActorSubsystem))...");
+```
+
+---
+
+## How to Apply
+
+These changes are already committed in the `Catalyst Rising/SpecialAgent_Plugin/` folder.
+You can copy the 5 modified `.cpp` files directly into your cloned fork and commit them,
+or run `git diff HEAD` from that folder to see the exact patch.
+
+## Tested On
+- Unreal Engine 5.7.3 (build `50162420+++UE5+Release-5.7`)
+- Windows 11
+- Plugin compiled successfully, MCP server running on port 8767


### PR DESCRIPTION
# SpecialAgent UE 5.7 Compatibility Fixes

These fixes were identified and applied during a live UE 5.7.3 build session.
The plugin compiled and ran successfully after these changes.

## Summary of Changes (5 files)

### 1. `Source/SpecialAgent/Private/SpecialAgentModule.cpp`

**Problem:** `FToolMenuSection::FindOrAddSection()` was removed in UE 5.7.

**Fix:** Replace with `AddSection()` + `FindSection()` pattern:

```cpp
// BEFORE (UE 5.5/5.6):
FToolMenuSection& Section = StatusBarMenu->FindOrAddSection(TEXT("SpecialAgent"));
Section.AddEntry(...);

// AFTER (UE 5.7):
const FName SectionName = TEXT("SpecialAgent");
FToolMenuSection* Section = StatusBarMenu->FindSection(SectionName);
if (!Section)
{
    StatusBarMenu->AddSection(SectionName, LOCTEXT("SpecialAgentSection", "SpecialAgent"));
    Section = StatusBarMenu->FindSection(SectionName);
}
if (Section)
{
    Section->AddEntry(...);
}
```

**Problem 2:** `GGameIni` is deprecated in UE 5.7.

**Fix:** Use explicit config file path:

```cpp
// BEFORE:
GConfig->GetBool(TEXT("..."), TEXT("ServerEnabled"), bAutoStart, GGameIni);
GConfig->GetInt(TEXT("..."), TEXT("ServerPort"), ServerPort, GGameIni);

// AFTER:
const FString ConfigPath = FPaths::ProjectConfigDir() / TEXT("DefaultSpecialAgent.ini");
GConfig->GetBool(TEXT("..."), TEXT("ServerEnabled"), bAutoStart, ConfigPath);
GConfig->GetInt(TEXT("..."), TEXT("ServerPort"), ServerPort, ConfigPath);
```

---

### 2. `Source/SpecialAgent/Private/MCPServer.cpp`

**Problem:** `StartAllListeners()` was called BEFORE routes were bound, causing the server
to start accepting connections before any handlers were registered — resulting in 404s on all requests.

**Fix:** Move `StartAllListeners()` to AFTER all `BindRoute()` calls:

```cpp
// BEFORE (broken ordering):
HttpServerModule.StartAllListeners();   // ← too early
HttpRouter = HttpServerModule.GetHttpRouter(ServerPort);
HttpRouter->BindRoute(...);  // routes bound after server started

// AFTER (correct):
HttpRouter = HttpServerModule.GetHttpRouter(ServerPort);
HttpRouter->BindRoute(...);  // bind all routes first
HttpRouter->BindRoute(...);
// ... all routes ...
HttpServerModule.StartAllListeners();   // ← start AFTER routes are registered
```

---

### 3. `Source/SpecialAgent/Private/Services/WorldService.cpp`

**Problem:** `#include "EditorLevelLibrary.h"` — `EditorLevelLibrary` is fully deprecated
and removed in UE 5.7. Causes compile error.

**Fix:**
```cpp
// BEFORE:
#include "EditorLevelLibrary.h"

// AFTER:
// UE 5.7: EditorLevelLibrary is deprecated; use subsystems instead
#include "Subsystems/EditorActorSubsystem.h"
#include "Subsystems/UnrealEditorSubsystem.h"
```

---

### 4. `Source/SpecialAgent/Private/MCPRequestRouter.cpp`

**Fix:** Updated documentation string to reference the correct UE 5.7 API:

```cpp
// BEFORE:
"2. Use unreal.EditorLevelLibrary or unreal.EditorAssetLibrary as needed\n"

// AFTER:
"2. Use unreal.get_editor_subsystem(unreal.EditorActorSubsystem) for actor ops, unreal.EditorAssetLibrary for assets\n"
```

---

### 5. `Source/SpecialAgent/Private/Services/PythonService.cpp`

**Fix:** Updated tool description to reference the correct UE 5.7 Python API:

```cpp
// BEFORE:
Tool.Description = TEXT("Execute Python with full UE5 API. Use for: spawning actors (unreal.EditorLevelLibrary)...");

// AFTER:
Tool.Description = TEXT("Execute Python with full UE5 API. Use for: spawning actors (unreal.get_editor_subsystem(unreal.EditorActorSubsystem))...");
```

---

## Tested On
- Unreal Engine 5.7.3 (build `50162420+++UE5+Release-5.7`)
- Windows 11
- Plugin compiled successfully, MCP server running on port 8767